### PR TITLE
Walk can take any prefix; it does not have to lookup a node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: go
 
 go:
-  - 1.13.x
-  - 1.14.x
+  - 1.16.x
   - tip
 
 before_script:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gammazero/radixtree
 
-go 1.12
+go 1.15

--- a/paths_test.go
+++ b/paths_test.go
@@ -382,6 +382,49 @@ func TestPathsCopyIterator(t *testing.T) {
 
 }
 
+func TestSimplePathWalk(t *testing.T) {
+	rt := new(Paths)
+	rt.Put("tom/ato", "TOMATO")
+	rt.Put("tom", "TOM")
+	rt.Put("torn/ad/o", "TORNADO")
+
+	count := 0
+	rt.Walk("tom/ato", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 1 {
+		t.Errorf("expected to visit 1 key, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("tom", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 2 {
+		t.Errorf("expected to visit 3 keys, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("tomx", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 0 {
+		t.Errorf("expected to visit 0 keys, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("torn", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 1 {
+		t.Errorf("expected to visit 1 key, visited %d", count)
+	}
+}
+
 func TestPaths(t *testing.T) {
 	testRadixTree(t, new(Paths))
 }

--- a/runes_test.go
+++ b/runes_test.go
@@ -532,6 +532,67 @@ func TestRunesCopyIterator(t *testing.T) {
 	}
 }
 
+func TestSimpleRunesWalk(t *testing.T) {
+	rt := new(Runes)
+	rt.Put("tomato", "TOMATO")
+	rt.Put("tom", "TOM")
+	rt.Put("tornado", "TORNADO")
+
+	count := 0
+	rt.Walk("tomato", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 1 {
+		t.Errorf("expected to visit 1 key, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("t", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 3 {
+		t.Errorf("expected to visit 3 keys, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("to", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 3 {
+		t.Errorf("expected to visit 3 keys, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("tom", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 2 {
+		t.Errorf("expected to visit 2 keys, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("tomx", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 0 {
+		t.Errorf("expected to visit 0 keys, visited %d", count)
+	}
+
+	count = 0
+	rt.Walk("torn", func(key KeyStringer, value interface{}) error {
+		count++
+		return nil
+	})
+	if count != 1 {
+		t.Errorf("expected to visit 1 key, visited %d", count)
+	}
+}
+
 func TestRunes(t *testing.T) {
 	testRadixTree(t, new(Runes))
 }


### PR DESCRIPTION
The Walk function can now be used to get all nodes whose key matches or is prefixed by the key passwd to Walk. This gets all nodes with a common prefix.  Previously Walk required a key that looked up an existing value.