### PR TITLE
feat: add support for generic values

### DIFF
--- a/bench_test.go
+++ b/bench_test.go
@@ -69,7 +69,7 @@ func benchmarkGet(b *testing.B, filePath string) {
 	if err != nil {
 		b.Skip(err.Error())
 	}
-	tree := new(Tree)
+	tree := New()
 	for _, w := range words {
 		tree.Put(w, w)
 	}
@@ -104,7 +104,7 @@ func benchmarkWalk(b *testing.B, filePath string) {
 	if err != nil {
 		b.Skip(err.Error())
 	}
-	tree := new(Tree)
+	tree := New()
 	for _, w := range words {
 		tree.Put(w, w)
 	}
@@ -128,7 +128,7 @@ func benchmarkWalkPath(b *testing.B, filePath string) {
 	if err != nil {
 		b.Skip(err.Error())
 	}
-	tree := new(Tree)
+	tree := New()
 	for _, w := range words {
 		tree.Put(w, w)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gammazero/radixtree
 
-go 1.17
+go 1.18

--- a/iterator.go
+++ b/iterator.go
@@ -5,29 +5,29 @@ package radixtree
 // Is is safe to use different Iterator instances concurrently. Any
 // modification to the Tree that the Iterator was created from invalidates the
 // Iterator instance.
-type Iterator struct {
-	nodes []*radixNode
+type Iterator[V any] struct {
+	nodes []*radixNode[V]
 }
 
 // NewIterator returns a new Iterator.
-func (t *Tree) NewIterator() *Iterator {
-	return &Iterator{
-		nodes: []*radixNode{&t.root},
+func (t *Tree[V]) NewIterator() *Iterator[V] {
+	return &Iterator[V]{
+		nodes: []*radixNode[V]{&t.root},
 	}
 }
 
 // Copy creates a new Iterator at this iterator's state of iteration.
-func (it *Iterator) Copy() *Iterator {
-	nodes := make([]*radixNode, len(it.nodes))
+func (it *Iterator[V]) Copy() *Iterator[V] {
+	nodes := make([]*radixNode[V], len(it.nodes))
 	copy(nodes, it.nodes)
-	return &Iterator{
+	return &Iterator[V]{
 		nodes: nodes,
 	}
 }
 
 // Next returns the next key and value stored in the Tree, and true when
 // iteration is complete.
-func (it *Iterator) Next() (key string, value interface{}, done bool) {
+func (it *Iterator[V]) Next() (key string, value V, done bool) {
 	for {
 		if len(it.nodes) == 0 {
 			break
@@ -43,5 +43,6 @@ func (it *Iterator) Next() (key string, value interface{}, done bool) {
 			return node.leaf.key, node.leaf.value, false
 		}
 	}
-	return "", nil, true
+	var zeroV V
+	return "", zeroV, true
 }

--- a/stepper.go
+++ b/stepper.go
@@ -3,15 +3,15 @@ package radixtree
 // Stepper traverses a Tree one byte at a time.
 //
 // Any modification to the tree invalidates the Stepper.
-type Stepper struct {
+type Stepper[V any] struct {
 	p    int
-	node *radixNode
+	node *radixNode[V]
 }
 
 // NewStepper returns a new Stepper instance that begins at the root of the
 // tree.
-func (t *Tree) NewStepper() *Stepper {
-	return &Stepper{
+func (t *Tree[V]) NewStepper() *Stepper[V] {
+	return &Stepper[V]{
 		node: &t.root,
 	}
 }
@@ -19,8 +19,8 @@ func (t *Tree) NewStepper() *Stepper {
 // Copy makes a copy of the current Stepper. This allows branching a Stepper
 // into two that can take separate paths. These Steppers do not affect each
 // other and can be used concurrently.
-func (s *Stepper) Copy() *Stepper {
-	return &Stepper{
+func (s *Stepper[V]) Copy() *Stepper[V] {
+	return &Stepper[V]{
 		p:    s.p,
 		node: s.node,
 	}
@@ -33,7 +33,7 @@ func (s *Stepper) Copy() *Stepper {
 //
 // When false is returned the Stepper is not modified. This allows different
 // values to be used in subsequent calls to Next.
-func (s *Stepper) Next(radix byte) bool {
+func (s *Stepper[V]) Next(radix byte) bool {
 	// The tree.prefix represents single-edge parents without values that were
 	// compressed out of the tree. Let prefix consume key symbols.
 	if s.p < len(s.node.prefix) {
@@ -58,14 +58,15 @@ func (s *Stepper) Next(radix byte) bool {
 
 // Value returns the value at the current Stepper position, and true or false
 // to indicate if a value is present at the position.
-func (s *Stepper) Value() (interface{}, bool) {
+func (s *Stepper[V]) Value() (V, bool) {
+	var zeroV V
 	// Only return value if all of this node's prefix was matched.  Otherwise,
 	// have not fully traversed into this node (edge not completely traversed).
 	if s.p != len(s.node.prefix) {
-		return nil, false
+		return zeroV, false
 	}
 	if s.node.leaf == nil {
-		return nil, false
+		return zeroV, false
 	}
 	return s.node.leaf.value, true
 }

--- a/stepper_test.go
+++ b/stepper_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestStepper(t *testing.T) {
-	rt := new(Tree)
+	rt := New()
 	rt.Put("tom", "TOM")
 	rt.Put("tomato", "TOMATO")
 	rt.Put("torn", "TORN")

--- a/tree_test.go
+++ b/tree_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestAddEnd(t *testing.T) {
-	rt := new(Tree)
+	rt := New()
 	rt.Put("tomato", "TOMATO")
 	if len(rt.root.edges) != 1 {
 		t.Fatal("root should have 1 child")
@@ -74,7 +74,7 @@ func TestAddEnd(t *testing.T) {
 }
 
 func TestAddFront(t *testing.T) {
-	rt := new(Tree)
+	rt := New()
 	rt.Put("tom", "TOM")
 	t.Log(dump(rt))
 	// (root) t-> ("om", TOM)
@@ -121,7 +121,7 @@ func TestAddFront(t *testing.T) {
 }
 
 func TestAddBranch(t *testing.T) {
-	rt := new(Tree)
+	rt := New()
 	rt.Put("tom", "TOM")
 	rt.Put("tomato", "TOMATO")
 
@@ -200,7 +200,7 @@ func TestAddBranch(t *testing.T) {
 }
 
 func TestAddBranchToBranch(t *testing.T) {
-	rt := new(Tree)
+	rt := New()
 	rt.Put("tom", "TOM")
 	rt.Put("tomato", "TOMATO")
 	rt.Put("torn", "TORN")
@@ -256,7 +256,7 @@ func TestAddBranchToBranch(t *testing.T) {
 }
 
 func TestAddExisting(t *testing.T) {
-	rt := new(Tree)
+	rt := New()
 	rt.Put("tom", "TOM")
 	rt.Put("tomato", "TOMATO")
 	rt.Put("torn", "TORN")
@@ -318,7 +318,7 @@ func TestAddExisting(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	rt := new(Tree)
+	rt := New()
 	rt.Put("tom", "TOM")
 	rt.Put("tomato", "TOMATO")
 	rt.Put("torn", "TORN")
@@ -358,7 +358,7 @@ func TestDelete(t *testing.T) {
 }
 
 func TestBuildEdgeCases(t *testing.T) {
-	tree := new(Tree)
+	tree := New()
 
 	tree.Put("ABCD", 1)
 	t.Log(dump(tree))
@@ -846,7 +846,7 @@ func TestWalk(t *testing.T) {
 
 	visited = make(map[string]int, len(keys))
 
-	var iterCopy *Iterator
+	var iterCopy *Iterator[any]
 	iter := tree.NewIterator()
 	for {
 		key, val, done := iter.Next()
@@ -1231,7 +1231,7 @@ func TestStringConvert(t *testing.T) {
 }
 
 // Use the Inspect functionality to create a function to dump the tree.
-func dump(tree *Tree) string {
+func dump(tree *Tree[any]) string {
 	var b strings.Builder
 	tree.Inspect(func(link, prefix, key string, depth, children int, hasValue bool, value interface{}) bool {
 		for ; depth > 0; depth-- {


### PR DESCRIPTION
This adds support for generic values in the tree.
Keys still are limited to strings.

This was born from an attempt at making the structure fully generic, but I couldn't find a nice way to make the keys generic without sacrificing the ergonomics of the `string` case.

Backward compatibility is kept for simple tree usage, but will require explicit types e.g. for `*Iterator` variables (as can be seen in `TestWalk`).

The change currently has a slight performance penalty on the `Get` case, and a slight performance improvement on the `Put` case:
```
name              old time/op    new time/op    delta
Get/Words-8         23.5ms ± 3%    25.7ms ± 4%  +9.50%  (p=0.008 n=5+5)
Get/Web2a-8         7.18ms ± 7%    7.99ms ±12%    ~     (p=0.056 n=5+5)
Put/Words-8         69.4ms ± 4%    68.0ms ± 2%    ~     (p=0.222 n=5+5)
Put/Web2a-8         22.5ms ± 2%    22.4ms ± 2%    ~     (p=0.548 n=5+5)
Walk/Words-8        7.41ms ± 7%    7.52ms ± 8%    ~     (p=0.841 n=5+5)
Walk/Web2a-8        1.43ms ±13%    1.54ms ± 9%    ~     (p=0.151 n=5+5)
WalkPath/Words-8    25.5ms ± 3%    27.0ms ± 5%  +5.99%  (p=0.008 n=5+5)
WalkPath/Web2a-8    7.59ms ± 4%    7.93ms ± 5%    ~     (p=0.151 n=5+5)

name              old alloc/op   new alloc/op   delta
Get/Words-8          0.00B          0.00B         ~     (all equal)
Get/Web2a-8          0.00B          0.00B         ~     (all equal)
Put/Words-8         36.5MB ± 0%    36.5MB ± 0%    ~     (p=0.171 n=4+4)
Put/Web2a-8         12.5MB ± 0%    12.5MB ± 0%    ~     (p=0.603 n=5+5)
Walk/Words-8         0.00B          0.00B         ~     (all equal)
Walk/Web2a-8         0.00B          0.00B         ~     (all equal)
WalkPath/Words-8     0.00B          0.00B         ~     (all equal)
WalkPath/Web2a-8     0.00B          0.00B         ~     (all equal)

name              old allocs/op  new allocs/op  delta
Get/Words-8           0.00           0.00         ~     (all equal)
Get/Web2a-8           0.00           0.00         ~     (all equal)
Put/Words-8          1.07M ± 0%     1.07M ± 0%    ~     (all equal)
Put/Web2a-8           352k ± 0%      352k ± 0%    ~     (all equal)
Walk/Words-8          0.00           0.00         ~     (all equal)
Walk/Web2a-8          0.00           0.00         ~     (all equal)
WalkPath/Words-8      0.00           0.00         ~     (all equal)
WalkPath/Web2a-8      0.00           0.00         ~     (all equal)
```

WDYT?