### PR TITLE
New DeletePrefix function

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.16
+        go-version: 1.20
 
     - name: Vet
       run: go vet ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.20
+        go-version: '1.20'
 
     - name: Vet
       run: go vet ./...

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ func main() {
     // Output: Found TOM
 
     // Find all items whose keys start with "tom"
-    rt.Walk("tom", func(key string, value interface{}) bool {
+    rt.Walk("tom", func(key string, value any) bool {
         fmt.Println(value)
         return false
     })
@@ -60,7 +60,7 @@ func main() {
     // TOMMY
 
     // Find all items whose keys are a prefix of "tomato"
-    rt.WalkPath("tomato", func(key string, value interface{}) bool {
+    rt.WalkPath("tomato", func(key string, value any) bool {
         fmt.Println(value)
         return false
     })

--- a/bench_test.go
+++ b/bench_test.go
@@ -92,7 +92,7 @@ func benchmarkPut(b *testing.B, filePath string) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for n := 0; n < b.N; n++ {
-		tree := new(Bytes)
+		tree := new(Tree)
 		for _, w := range words {
 			tree.Put(w, w)
 		}
@@ -113,7 +113,7 @@ func benchmarkWalk(b *testing.B, filePath string) {
 	var count int
 	for n := 0; n < b.N; n++ {
 		count = 0
-		tree.Walk("", func(k string, value interface{}) bool {
+		tree.Walk("", func(k string, value any) bool {
 			count++
 			return false
 		})
@@ -137,7 +137,7 @@ func benchmarkWalkPath(b *testing.B, filePath string) {
 	for n := 0; n < b.N; n++ {
 		found := false
 		for _, w := range words {
-			tree.WalkPath(w, func(key string, value interface{}) bool {
+			tree.WalkPath(w, func(key string, value any) bool {
 				found = true
 				return false
 			})

--- a/doc_test.go
+++ b/doc_test.go
@@ -14,7 +14,7 @@ func ExampleTree_Walk() {
 	rt.Put("tornado", "TORNADO")
 
 	// Find all items whose keys start with "tom"
-	rt.Walk("tom", func(key string, value interface{}) bool {
+	rt.Walk("tom", func(key string, value any) bool {
 		fmt.Println(value)
 		return false
 	})
@@ -28,7 +28,7 @@ func ExampleTree_WalkPath() {
 	rt.Put("tornado", "TORNADO")
 
 	// Find all items that are a prefix of "tomato"
-	rt.WalkPath("tomato", func(key string, value interface{}) bool {
+	rt.WalkPath("tomato", func(key string, value any) bool {
 		fmt.Println(value)
 		return false
 	})

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gammazero/radixtree
 
-go 1.17
+go 1.18

--- a/iterator.go
+++ b/iterator.go
@@ -27,7 +27,7 @@ func (it *Iterator) Copy() *Iterator {
 
 // Next returns the next key and value stored in the Tree, and true when
 // iteration is complete.
-func (it *Iterator) Next() (key string, value interface{}, done bool) {
+func (it *Iterator) Next() (key string, value any, done bool) {
 	for {
 		if len(it.nodes) == 0 {
 			break

--- a/stepper.go
+++ b/stepper.go
@@ -58,7 +58,7 @@ func (s *Stepper) Next(radix byte) bool {
 
 // Value returns the value at the current Stepper position, and true or false
 // to indicate if a value is present at the position.
-func (s *Stepper) Value() (interface{}, bool) {
+func (s *Stepper) Value() (any, bool) {
 	// Only return value if all of this node's prefix was matched.  Otherwise,
 	// have not fully traversed into this node (edge not completely traversed).
 	if s.p != len(s.node.prefix) {

--- a/tree_test.go
+++ b/tree_test.go
@@ -357,6 +357,45 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestDeletePrefix(t *testing.T) {
+	rt := new(Tree)
+	rt.Put("tom", "TOM")
+	rt.Put("tomato", "TOMATO")
+	rt.Put("torn", "TORN")
+	rt.Put("tag", "TAG")
+	rt.Put("tornado", "TORNADO")
+	prevSize := rt.Len()
+
+	if rt.DeletePrefix("tox") {
+		t.Fatal("should not have deleted prefix")
+	}
+
+	if !rt.DeletePrefix("tom") {
+		t.Fatal("did not delete prefix")
+	}
+
+	if rt.Len() != (prevSize - 2) {
+		t.Fatal("Expected size to decrease by 2")
+	}
+	prevSize = rt.Len()
+
+	if rt.DeletePrefix("torx") {
+		t.Fatal("deleted prefix")
+	}
+
+	if !rt.DeletePrefix("tor") {
+		t.Fatal("did not delete prefix")
+	}
+
+	if rt.Len() != (prevSize - 2) {
+		t.Fatal("Expected size to decrease by 2")
+	}
+
+	if !rt.DeletePrefix("tag") {
+		t.Fatal("should have deleted prefix")
+	}
+}
+
 func TestBuildEdgeCases(t *testing.T) {
 	tree := new(Tree)
 
@@ -502,7 +541,7 @@ func TestSimpleWalk(t *testing.T) {
 	rt.Put("tornado", "TORNADO")
 
 	count := 0
-	rt.Walk("tomato", func(key string, value interface{}) bool {
+	rt.Walk("tomato", func(key string, value any) bool {
 		count++
 		return false
 	})
@@ -511,7 +550,7 @@ func TestSimpleWalk(t *testing.T) {
 	}
 
 	count = 0
-	rt.Walk("t", func(key string, value interface{}) bool {
+	rt.Walk("t", func(key string, value any) bool {
 		count++
 		return false
 	})
@@ -520,7 +559,7 @@ func TestSimpleWalk(t *testing.T) {
 	}
 
 	count = 0
-	rt.Walk("to", func(key string, value interface{}) bool {
+	rt.Walk("to", func(key string, value any) bool {
 		count++
 		return false
 	})
@@ -529,7 +568,7 @@ func TestSimpleWalk(t *testing.T) {
 	}
 
 	count = 0
-	rt.Walk("tom", func(key string, value interface{}) bool {
+	rt.Walk("tom", func(key string, value any) bool {
 		count++
 		return false
 	})
@@ -538,7 +577,7 @@ func TestSimpleWalk(t *testing.T) {
 	}
 
 	count = 0
-	rt.Walk("tomx", func(key string, value interface{}) bool {
+	rt.Walk("tomx", func(key string, value any) bool {
 		count++
 		return false
 	})
@@ -547,7 +586,7 @@ func TestSimpleWalk(t *testing.T) {
 	}
 
 	count = 0
-	rt.Walk("torn", func(key string, value interface{}) bool {
+	rt.Walk("torn", func(key string, value any) bool {
 		count++
 		return false
 	})
@@ -606,9 +645,9 @@ func TestTree(t *testing.T) {
 		}
 	}
 
-	var wvals []interface{}
-	kvMap := map[string]interface{}{}
-	walkFn := func(key string, value interface{}) bool {
+	var wvals []any
+	kvMap := map[string]any{}
+	walkFn := func(key string, value any) bool {
 		kvMap[key] = value
 		wvals = append(wvals, value)
 		return false
@@ -622,14 +661,14 @@ func TestTree(t *testing.T) {
 		t.Error("should not have returned values, got ", kvMap)
 	}
 	lastKey := keys[len(keys)-1]
-	var expectVals []interface{}
+	var expectVals []any
 	for _, key := range keys {
 		// If key is a prefix of lastKey, then expect value.
 		if strings.HasPrefix(lastKey, key) {
 			expectVals = append(expectVals, strings.ToUpper(key))
 		}
 	}
-	kvMap = map[string]interface{}{}
+	kvMap = map[string]any{}
 	wvals = nil
 	tree.WalkPath(lastKey, walkFn)
 	if kvMap[lastKey] == nil {
@@ -782,7 +821,7 @@ func TestWalk(t *testing.T) {
 	}
 
 	var err error
-	walkFn := func(key string, value interface{}) bool {
+	walkFn := func(key string, value any) bool {
 		// value for each walked key is correct
 		if value != strings.ToUpper(key) {
 			err = fmt.Errorf("expected key %s to have value %v, got %v", key, strings.ToUpper(key), value)
@@ -958,7 +997,7 @@ func TestWalk(t *testing.T) {
 	keys = append(keys, testKey)
 	tree.Put(testKey, strings.ToUpper(testKey))
 
-	walkPFn := func(key string, value interface{}) bool {
+	walkPFn := func(key string, value any) bool {
 		// value for each walked key is correct
 		v := strings.ToUpper(key)
 		if value != v {
@@ -982,7 +1021,7 @@ func TestWalk(t *testing.T) {
 	for _, k := range keys {
 		visited[k] = 0
 	}
-	tree.WalkPath(testKey, func(key string, value interface{}) bool {
+	tree.WalkPath(testKey, func(key string, value any) bool {
 		pfx := "rat/winks/wryly"
 		if strings.HasPrefix(key, pfx) && len(key) > len(pfx) {
 			return false
@@ -999,7 +1038,7 @@ func TestWalk(t *testing.T) {
 	for _, k := range keys {
 		visited[k] = 0
 	}
-	tree.WalkPath(testKey, func(key string, value interface{}) bool {
+	tree.WalkPath(testKey, func(key string, value any) bool {
 		visited[key]++
 		if key == "rat/winks/wryly" {
 			err = fmt.Errorf("error at key %s", key)
@@ -1017,7 +1056,7 @@ func TestWalk(t *testing.T) {
 
 	var foundRoot bool
 	tree.Put("", "ROOT")
-	tree.WalkPath(testKey, func(key string, value interface{}) bool {
+	tree.WalkPath(testKey, func(key string, value any) bool {
 		if key == "" && value == "ROOT" {
 			foundRoot = true
 		}
@@ -1031,7 +1070,7 @@ func TestWalk(t *testing.T) {
 		visited[k] = 0
 	}
 
-	tree.WalkPath(testKey, func(key string, value interface{}) bool {
+	tree.WalkPath(testKey, func(key string, value any) bool {
 		if key == "" && value == "ROOT" {
 			return false
 		}
@@ -1043,7 +1082,7 @@ func TestWalk(t *testing.T) {
 		}
 	}
 
-	tree.WalkPath(testKey, func(key string, value interface{}) bool {
+	tree.WalkPath(testKey, func(key string, value any) bool {
 		if key == "" && value == "ROOT" {
 			err = errors.New("error at root")
 			return true
@@ -1060,7 +1099,7 @@ func TestWalk(t *testing.T) {
 	}
 
 	var lastKey string
-	tree.WalkPath("rat/winks/wisely/x/y/z/w", func(key string, value interface{}) bool {
+	tree.WalkPath("rat/winks/wisely/x/y/z/w", func(key string, value any) bool {
 		lastKey = key
 		return false
 	})
@@ -1109,7 +1148,7 @@ func TestWalkStop(t *testing.T) {
 	walkErr := errors.New("walk error")
 	var walked int
 	var err error
-	walkFn := func(k string, value interface{}) bool {
+	walkFn := func(k string, value any) bool {
 		if value == 999 {
 			err = walkErr
 			return true
@@ -1144,7 +1183,7 @@ func TestInspectStop(t *testing.T) {
 		tree.Put(table[i].key, table[i].val)
 	}
 	var keys []string
-	inspectFn := func(link, prefix, key string, depth, children int, hasValue bool, value interface{}) bool {
+	inspectFn := func(link, prefix, key string, depth, children int, hasValue bool, value any) bool {
 		if !hasValue {
 			// Do not count internal nodes
 			return false
@@ -1214,7 +1253,7 @@ func TestStringConvert(t *testing.T) {
 			t.Fatalf("returned wrong value - expected %q got %q", w, s)
 		}
 	}
-	tree.Walk("", func(key string, val interface{}) bool {
+	tree.Walk("", func(key string, val any) bool {
 		t.Log("Key:", key)
 		s, ok := val.(string)
 		if !ok {
@@ -1233,7 +1272,7 @@ func TestStringConvert(t *testing.T) {
 // Use the Inspect functionality to create a function to dump the tree.
 func dump(tree *Tree) string {
 	var b strings.Builder
-	tree.Inspect(func(link, prefix, key string, depth, children int, hasValue bool, value interface{}) bool {
+	tree.Inspect(func(link, prefix, key string, depth, children int, hasValue bool, value any) bool {
 		for ; depth > 0; depth-- {
 			b.WriteString("  ")
 		}


### PR DESCRIPTION
The DeletePrefix removes all values whose key is prefixed by the given prefix. This prunes an entire subtree and is therefore more efficient that deleting individual items.